### PR TITLE
Separate actor behaviour and data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ set(SOURCES
 		src/pickup.cpp
 		src/effect.cpp
 		src/interactable.cpp
-		src/actor_types.cpp
 		src/spawner.cpp
 		src/debug.cpp
 		src/shader.cpp

--- a/src/actor_behaviour.h
+++ b/src/actor_behaviour.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "typedef.h"
+#include "player.h"
+#include "enemy.h"
+#include "bullet.h"
+#include "pickup.h"
+#include "effect.h"
+#include "interactable.h"
+#include "spawner.h"
+
+namespace Game {
+	constexpr ActorInitFn const* actorInitTable[ACTOR_TYPE_COUNT] = {
+		playerInitTable,
+		enemyInitTable,
+		bulletInitTable,
+		pickupInitTable,
+		effectInitTable,
+		interactableInitTable,
+		spawnerInitTable,
+	};
+
+	constexpr ActorUpdateFn const* actorUpdateTable[ACTOR_TYPE_COUNT] = {
+		playerUpdateTable,
+		enemyUpdateTable,
+		bulletUpdateTable,
+		pickupUpdateTable,
+		effectUpdateTable,
+		interactableUpdateTable,
+		spawnerUpdateTable,
+	};
+
+	constexpr ActorDrawFn const* actorDrawTable[ACTOR_TYPE_COUNT] = {
+		playerDrawTable,
+		enemyDrawTable,
+		bulletDrawTable,
+		pickupDrawTable,
+		effectDrawTable,
+		interactableDrawTable,
+		spawnerDrawTable,
+	};
+}

--- a/src/actor_data.h
+++ b/src/actor_data.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "typedef.h"
-#include "player.h"
-#include "enemy.h"
-#include "bullet.h"
-#include "pickup.h"
-#include "effect.h"
-#include "interactable.h"
-#include "spawner.h"
+#include "player_data.h"
+#include "enemy_data.h"
+#include "bullet_data.h"
+#include "pickup_data.h"
+#include "effect_data.h"
+#include "interactable_data.h"
+#include "spawner_data.h"
 
 enum ActorType : TActorType {
 	ACTOR_TYPE_PLAYER,
@@ -45,38 +45,6 @@ union ActorState {
 	ExpSpawnerState expSpawner;
 };
 
-namespace Game {
-	constexpr ActorInitFn const* actorInitTable[ACTOR_TYPE_COUNT] = {
-		playerInitTable,
-		enemyInitTable,
-		bulletInitTable,
-		pickupInitTable,
-		effectInitTable,
-		interactableInitTable,
-		spawnerInitTable,
-	};
-
-	constexpr ActorUpdateFn const* actorUpdateTable[ACTOR_TYPE_COUNT] = {
-		playerUpdateTable,
-		enemyUpdateTable,
-		bulletUpdateTable,
-		pickupUpdateTable,
-		effectUpdateTable,
-		interactableUpdateTable,
-		spawnerUpdateTable,
-	};
-
-	constexpr ActorDrawFn const* actorDrawTable[ACTOR_TYPE_COUNT] = {
-		playerDrawTable,
-		enemyDrawTable,
-		bulletDrawTable,
-		pickupDrawTable,
-		effectDrawTable,
-		interactableDrawTable,
-		spawnerDrawTable,
-	};
-}
-
 #ifdef EDITOR
 #include "editor_actor.h"
 
@@ -84,13 +52,13 @@ namespace Editor {
 	constexpr const char* actorTypeNames[ACTOR_TYPE_COUNT] = { "Player", "Enemy", "Bullet", "Pickup", "Effect", "Interactable", "Spawner" };
 
 	inline static const ActorEditorData actorEditorData[ACTOR_TYPE_COUNT] = {
-		playerEditorData,
-		enemyEditorData,
-		bulletEditorData,
-		pickupEditorData,
-		effectEditorData,
-		interactableEditorData,
-		spawnerEditorData,
+		GetPlayerEditorData(),
+		GetEnemyEditorData(),
+		GetBulletEditorData(),
+		GetPickupEditorData(),
+		GetEffectEditorData(),
+		GetInteractableEditorData(),
+		GetSpawnerEditorData(),
 	};
 }
 

--- a/src/actor_prototypes.h
+++ b/src/actor_prototypes.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "typedef.h"
 #include "collision.h"
-#include "actor_types.h"
+#include "actor_data.h"
 #include "asset_types.h"
 
 struct ActorPrototype {

--- a/src/actor_reflection.h
+++ b/src/actor_reflection.h
@@ -9,7 +9,7 @@
 	{ .name = #FIELD, .type = ACTOR_EDITOR_PROPERTY_ASSET, .assetType = ASSET_TYPE, .components = COMPONENTS, .offset = offsetof(STRUCT_TYPE, FIELD) }
 
 #define ACTOR_SUBTYPE_PROPERTIES(STRUCT_TYPE, ...) \
-	inline const std::vector<ActorEditorProperty>& Get##STRUCT_TYPE##EditorProperties() { \
+	inline static const std::vector<ActorEditorProperty>& Get##STRUCT_TYPE##EditorProperties() { \
 		static const std::vector<ActorEditorProperty> properties = { __VA_ARGS__ }; \
 		return properties; \
 	} \
@@ -17,14 +17,10 @@
 #define GET_SUBTYPE_PROPERTIES(STRUCT_TYPE) \
 		Get##STRUCT_TYPE##EditorProperties()
 
-#define DECLARE_ACTOR_EDITOR_DATA(ACTOR_TYPE) \
-	namespace Editor { \
-		extern const ActorEditorData ACTOR_TYPE##EditorData; \
-	} \
-
-#define DEFINE_ACTOR_EDITOR_DATA(ACTOR_TYPE, ...) \
-	namespace Editor { \
-		const ActorEditorData ACTOR_TYPE##EditorData = ActorEditorData({ __VA_ARGS__ }); \
+#define ACTOR_EDITOR_DATA(ACTOR_TYPE, ...) \
+	inline static const ActorEditorData Get##ACTOR_TYPE##EditorData() { \
+		static const ActorEditorData editorData = ActorEditorData({ __VA_ARGS__ }); \
+		return editorData; \
 	} \
 
 #else
@@ -33,6 +29,5 @@
 #define ACTOR_SUBTYPE_PROPERTIES(STRUCT_TYPE, ...)
 #define GET_SUBTYPE_PROPERTIES(STRUCT_TYPE) \
 		{}
-#define DECLARE_ACTOR_EDITOR_DATA(ACTOR_TYPE)
-#define DEFINE_ACTOR_EDITOR_DATA(ACTOR_TYPE, ...)
+#define ACTOR_EDITOR_DATA(ACTOR_TYPE, ...)
 #endif

--- a/src/actor_types.cpp
+++ b/src/actor_types.cpp
@@ -1,2 +1,0 @@
-#include "actor_types.h"
-

--- a/src/actors.h
+++ b/src/actors.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "typedef.h"
-#include "actor_types.h"
+#include "actor_data.h"
+#include "actor_behaviour.h"
 #define GLM_FORCE_RADIANS
 #include <glm.hpp>
 #include "memory_pool.h"

--- a/src/bullet.cpp
+++ b/src/bullet.cpp
@@ -104,8 +104,3 @@ constexpr ActorDrawFn Game::bulletDrawTable[BULLET_TYPE_COUNT] = {
     Game::DrawActorDefault,
     Game::DrawActorDefault,
 };
-
-DEFINE_ACTOR_EDITOR_DATA(bullet,
-	{ "bullet", GET_SUBTYPE_PROPERTIES(BulletData) },
-	{ "grenade", GET_SUBTYPE_PROPERTIES(BulletData) }
-);

--- a/src/bullet.h
+++ b/src/bullet.h
@@ -1,33 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
-
-enum BulletType : TActorSubtype {
-	BULLET_TYPE_DEFAULT,
-	BULLET_TYPE_GRENADE,
-
-	BULLET_TYPE_COUNT
-};
-
-struct BulletData {
-	u16 lifetime;
-	ActorPrototypeHandle deathEffect;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(BulletData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(BulletData, lifetime, U16, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(BulletData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
-)
-
-struct BulletState {
-	u16 lifetimeCounter;
-};
+#include "bullet_data.h"
 
 namespace Game {
 	extern const ActorInitFn bulletInitTable[BULLET_TYPE_COUNT];
 	extern const ActorUpdateFn bulletUpdateTable[BULLET_TYPE_COUNT];
 	extern const ActorDrawFn bulletDrawTable[BULLET_TYPE_COUNT];
 }
-
-DECLARE_ACTOR_EDITOR_DATA(bullet)

--- a/src/bullet_data.h
+++ b/src/bullet_data.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum BulletType : TActorSubtype {
+	BULLET_TYPE_DEFAULT,
+	BULLET_TYPE_GRENADE,
+
+	BULLET_TYPE_COUNT
+};
+
+struct BulletData {
+	u16 lifetime;
+	ActorPrototypeHandle deathEffect;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(BulletData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(BulletData, lifetime, U16, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(BulletData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
+)
+
+struct BulletState {
+	u16 lifetimeCounter;
+};
+
+ACTOR_EDITOR_DATA(Bullet,
+	{ "bullet", GET_SUBTYPE_PROPERTIES(BulletData) },
+	{ "grenade", GET_SUBTYPE_PROPERTIES(BulletData) }
+);

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -133,9 +133,3 @@ constexpr ActorDrawFn Game::effectDrawTable[EFFECT_TYPE_COUNT] = {
     Game::DrawActorDefault,
     Game::DrawActorDefault,
 };
-
-DEFINE_ACTOR_EDITOR_DATA(effect,
-    { "damage_numbers", GET_SUBTYPE_PROPERTIES(EffectData) },
-    { "explosion", GET_SUBTYPE_PROPERTIES(EffectData) },
-    { "feather", GET_SUBTYPE_PROPERTIES(EffectData) }
-)

--- a/src/effect.h
+++ b/src/effect.h
@@ -1,56 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
-
-enum EffectType : TActorSubtype {
-	EFFECT_TYPE_NUMBERS,
-	EFFECT_TYPE_EXPLOSION,
-	EFFECT_TYPE_FEATHER,
-
-	EFFECT_TYPE_COUNT
-};
-
-struct EffectData {
-	u16 lifetime;
-	SoundHandle sound;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(EffectData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(EffectData, lifetime, U16, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(EffectData, sound, ASSET_TYPE_SOUND, 1)
-);
-
-struct EffectState {
-	u16 initialLifetime;
-	u16 lifetimeCounter;
-};
-
-struct DamageFlags {
-	bool healing : 1;
-	bool crit : 1;
-	u8 type : 3; // TODO: Add damage types?
-};
-
-struct Damage {
-	u16 value;
-	DamageFlags flags;
-};
-
-// Can be treated as EffectState
-struct DamageNumberState {
-	EffectState base;
-	Damage damage;
-};
-
-#ifdef EDITOR
-constexpr const char* EFFECT_TYPE_NAMES[EFFECT_TYPE_COUNT] = { "Damage numbers", "Explosion", "Feather" };
-#endif
+#include "effect_data.h"
 
 namespace Game {
 	extern const ActorInitFn effectInitTable[EFFECT_TYPE_COUNT];
 	extern const ActorUpdateFn effectUpdateTable[EFFECT_TYPE_COUNT];
 	extern const ActorDrawFn effectDrawTable[EFFECT_TYPE_COUNT];
 }
-
-DECLARE_ACTOR_EDITOR_DATA(effect)

--- a/src/effect_data.h
+++ b/src/effect_data.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum EffectType : TActorSubtype {
+	EFFECT_TYPE_NUMBERS,
+	EFFECT_TYPE_EXPLOSION,
+	EFFECT_TYPE_FEATHER,
+
+	EFFECT_TYPE_COUNT
+};
+
+struct EffectData {
+	u16 lifetime;
+	SoundHandle sound;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(EffectData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(EffectData, lifetime, U16, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(EffectData, sound, ASSET_TYPE_SOUND, 1)
+);
+
+struct EffectState {
+	u16 initialLifetime;
+	u16 lifetimeCounter;
+};
+
+struct DamageFlags {
+	bool healing : 1;
+	bool crit : 1;
+	u8 type : 3; // TODO: Add damage types?
+};
+
+struct Damage {
+	u16 value;
+	DamageFlags flags;
+};
+
+// Can be treated as EffectState
+struct DamageNumberState {
+	EffectState base;
+	Damage damage;
+};
+
+ACTOR_EDITOR_DATA(Effect,
+	{ "damage_numbers", GET_SUBTYPE_PROPERTIES(EffectData) },
+	{ "explosion", GET_SUBTYPE_PROPERTIES(EffectData) },
+	{ "feather", GET_SUBTYPE_PROPERTIES(EffectData) }
+)

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -158,9 +158,3 @@ constexpr ActorDrawFn Game::enemyDrawTable[ENEMY_TYPE_COUNT] = {
     Game::DrawActorDefault,
     Game::DrawActorDefault,
 };
-
-DEFINE_ACTOR_EDITOR_DATA(enemy,
-	{ "slime", GET_SUBTYPE_PROPERTIES(EnemyData) },
-	{ "skull", GET_SUBTYPE_PROPERTIES(EnemyData) },
-	{ "fireball", GET_SUBTYPE_PROPERTIES(FireballData) }
-);

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -1,54 +1,5 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
-#include <cstddef>
-
-enum NPCSubtype : TActorSubtype {
-	ENEMY_TYPE_SLIME,
-	ENEMY_TYPE_SKULL,
-	ENEMY_TYPE_FIREBALL,
-
-	ENEMY_TYPE_COUNT
-};
-
-struct EnemyData {
-	u16 health;
-
-	u16 expValue;
-	ActorPrototypeHandle lootSpawner;
-	ActorPrototypeHandle deathEffect;
-	ActorPrototypeHandle projectile;
-	ActorPrototypeHandle expSpawner;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(EnemyData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(EnemyData, health, U16, 1),
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(EnemyData, expValue, U16, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, lootSpawner, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, projectile, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, expSpawner, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
-)
-
-struct FireballData {
-	u16 lifetime;
-	ActorPrototypeHandle deathEffect;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(FireballData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(FireballData, lifetime, U16, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(FireballData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
-)
-
-struct EnemyState {
-	u16 health;
-	u16 damageCounter;
-};
-
-struct FireballState {
-	u16 lifetimeCounter;
-};
+#include "enemy_data.h"
 
 struct Actor;
 struct ActorPrototype;
@@ -60,5 +11,3 @@ namespace Game {
 
 	void EnemyDie(Actor* pActor, const ActorPrototype* pPrototype);
 }
-
-DECLARE_ACTOR_EDITOR_DATA(enemy)

--- a/src/enemy_data.h
+++ b/src/enemy_data.h
@@ -1,0 +1,55 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum EnemyType : TActorSubtype {
+	ENEMY_TYPE_SLIME,
+	ENEMY_TYPE_SKULL,
+	ENEMY_TYPE_FIREBALL,
+
+	ENEMY_TYPE_COUNT
+};
+
+struct EnemyData {
+	u16 health;
+
+	u16 expValue;
+	ActorPrototypeHandle lootSpawner;
+	ActorPrototypeHandle deathEffect;
+	ActorPrototypeHandle projectile;
+	ActorPrototypeHandle expSpawner;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(EnemyData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(EnemyData, health, U16, 1),
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(EnemyData, expValue, U16, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, lootSpawner, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, projectile, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(EnemyData, expSpawner, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
+)
+
+struct FireballData {
+	u16 lifetime;
+	ActorPrototypeHandle deathEffect;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(FireballData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(FireballData, lifetime, U16, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(FireballData, deathEffect, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
+)
+
+struct EnemyState {
+	u16 health;
+	u16 damageCounter;
+};
+
+struct FireballState {
+	u16 lifetimeCounter;
+};
+
+ACTOR_EDITOR_DATA(Enemy,
+	{ "slime", GET_SUBTYPE_PROPERTIES(EnemyData) },
+	{ "skull", GET_SUBTYPE_PROPERTIES(EnemyData) },
+	{ "fireball", GET_SUBTYPE_PROPERTIES(FireballData) }
+);

--- a/src/interactable.cpp
+++ b/src/interactable.cpp
@@ -39,8 +39,3 @@ constexpr ActorDrawFn Game::interactableDrawTable[INTERACTABLE_TYPE_COUNT] = {
     Game::DrawActorDefault,
     Game::DrawActorDefault
 };
-
-DEFINE_ACTOR_EDITOR_DATA(interactable,
-	{ "checkpoint", GET_SUBTYPE_PROPERTIES(CheckpointData) },
-	{ "npc", GET_SUBTYPE_PROPERTIES(NPCData) }
-);

--- a/src/interactable.h
+++ b/src/interactable.h
@@ -1,38 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "actor_reflection.h"
-
-enum CheckpointSubtype : TActorSubtype {
-	INTERACTABLE_TYPE_CHECKPOINT,
-	INTERACTABLE_TYPE_NPC,
-
-	INTERACTABLE_TYPE_COUNT
-};
-
-struct CheckpointData {
-
-};
-
-ACTOR_SUBTYPE_PROPERTIES(CheckpointData)
-
-struct CheckpointState {
-	bool activated;
-};
-
-struct NPCData {
-
-};
-
-ACTOR_SUBTYPE_PROPERTIES(NPCData)
-
-#ifdef EDITOR
-constexpr const char* INTERACTABLE_TYPE_NAMES[INTERACTABLE_TYPE_COUNT] = { "Default" };
-#endif
+#include "interactable_data.h"
 
 namespace Game {
 	extern const ActorInitFn interactableInitTable[INTERACTABLE_TYPE_COUNT];
 	extern const ActorUpdateFn interactableUpdateTable[INTERACTABLE_TYPE_COUNT];
 	extern const ActorDrawFn interactableDrawTable[INTERACTABLE_TYPE_COUNT];
 }
-
-DECLARE_ACTOR_EDITOR_DATA(interactable)

--- a/src/interactable_data.h
+++ b/src/interactable_data.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum CheckpointSubtype : TActorSubtype {
+	INTERACTABLE_TYPE_CHECKPOINT,
+	INTERACTABLE_TYPE_NPC,
+
+	INTERACTABLE_TYPE_COUNT
+};
+
+struct CheckpointData {
+
+};
+
+ACTOR_SUBTYPE_PROPERTIES(CheckpointData)
+
+struct CheckpointState {
+	bool activated;
+};
+
+struct NPCData {
+
+};
+
+ACTOR_SUBTYPE_PROPERTIES(NPCData)
+
+ACTOR_EDITOR_DATA(Interactable,
+	{ "checkpoint", GET_SUBTYPE_PROPERTIES(CheckpointData) },
+	{ "npc", GET_SUBTYPE_PROPERTIES(NPCData) }
+)

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -127,9 +127,3 @@ constexpr ActorDrawFn Game::pickupDrawTable[PICKUP_TYPE_COUNT] = {
     Game::DrawActorDefault,
     Game::DrawActorDefault,
 };
-
-DEFINE_ACTOR_EDITOR_DATA(pickup,
-	{ "exp", GET_SUBTYPE_PROPERTIES(PickupData) },
-	{ "exp_remnant", GET_SUBTYPE_PROPERTIES(PickupData) },
-	{ "healing", GET_SUBTYPE_PROPERTIES(PickupData) }
-)

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -1,35 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
-
-enum PickupType : TActorSubtype {
-	PICKUP_TYPE_EXP,
-	PICKUP_TYPE_EXP_REMNANT,
-	PICKUP_TYPE_HEAL,
-
-	PICKUP_TYPE_COUNT
-};
-
-struct PickupData {
-	s16 value;
-	SoundHandle pickupSound;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(PickupData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(PickupData, value, S16, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(PickupData, pickupSound, ASSET_TYPE_SOUND, 1)
-)
-
-struct PickupState {
-	s16 value;
-	u16 lingerCounter;
-};
+#include "pickup_data.h"
 
 namespace Game {
 	extern const ActorInitFn pickupInitTable[PICKUP_TYPE_COUNT];
 	extern const ActorUpdateFn pickupUpdateTable[PICKUP_TYPE_COUNT];
 	extern const ActorDrawFn pickupDrawTable[PICKUP_TYPE_COUNT];
 }
-
-DECLARE_ACTOR_EDITOR_DATA(pickup)

--- a/src/pickup_data.h
+++ b/src/pickup_data.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum PickupType : TActorSubtype {
+	PICKUP_TYPE_EXP,
+	PICKUP_TYPE_EXP_REMNANT,
+	PICKUP_TYPE_HEAL,
+
+	PICKUP_TYPE_COUNT
+};
+
+struct PickupData {
+	s16 value;
+	SoundHandle pickupSound;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(PickupData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(PickupData, value, S16, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(PickupData, pickupSound, ASSET_TYPE_SOUND, 1)
+)
+
+struct PickupState {
+	s16 value;
+	u16 lingerCounter;
+};
+
+ACTOR_EDITOR_DATA(Pickup,
+	{ "exp", GET_SUBTYPE_PROPERTIES(PickupData) },
+	{ "exp_remnant", GET_SUBTYPE_PROPERTIES(PickupData) },
+	{ "healing", GET_SUBTYPE_PROPERTIES(PickupData) }
+)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -830,8 +830,3 @@ constexpr ActorDrawFn Game::playerDrawTable[PLAYER_TYPE_COUNT] = {
     DrawPlayerSidescroller,
     DrawPlayerOverworld
 };
-
-DEFINE_ACTOR_EDITOR_DATA(player,
-    { "sidescroller", GET_SUBTYPE_PROPERTIES(PlayerData) },
-    { "overworld", GET_SUBTYPE_PROPERTIES(PlayerOverworldData) }
-)

--- a/src/player.h
+++ b/src/player.h
@@ -1,17 +1,7 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
+#include "player_data.h"
 #define GLM_FORCE_RADIANS
 #include <glm.hpp>
-
-#pragma region Player
-enum PlayerType : TActorSubtype {
-	PLAYER_TYPE_SIDESCROLLER,
-	PLAYER_TYPE_OVERWORLD,
-
-	PLAYER_TYPE_COUNT
-};
 
 enum PlayerWeaponType : u8 {
 	PLAYER_WEAPON_BOW,
@@ -29,48 +19,6 @@ enum PlayerModeBits : u8 {
 	PLAYER_MODE_DODGE,
 };
 
-struct PlayerData {
-	SoundHandle jumpSound;
-	SoundHandle damageSound;
-	SoundHandle gunSound; // TEMP!
-};
-
-ACTOR_SUBTYPE_PROPERTIES(PlayerData,
-	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, jumpSound, ASSET_TYPE_SOUND, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, damageSound, ASSET_TYPE_SOUND, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, gunSound, ASSET_TYPE_SOUND, 1)
-);
-
-struct PlayerFlags {
-	u8 aimMode : 2;
-	bool slowFall : 1;
-	bool doubleJumped : 1;
-	bool airDodged : 1;
-	u8 mode : 4;
-};
-
-struct PlayerState {
-	PlayerFlags flags;
-
-	u16 wingCounter;
-	u16 wingFrame;
-	u16 shootCounter;
-	
-	u16 modeTransitionCounter;
-	u16 staminaRecoveryCounter;
-};
-
-struct PlayerOverworldData {
-
-};
-
-ACTOR_SUBTYPE_PROPERTIES(PlayerOverworldData)
-
-struct PlayerOverworldState {
-	glm::ivec2 facingDir;
-	u16 movementCounter;
-};
-
 struct Actor;
 struct Damage;
 
@@ -82,5 +30,3 @@ namespace Game {
 	bool PlayerInvulnerable(Actor* pPlayer);
 	void PlayerTakeDamage(Actor* pPlayer, const Damage& damage, const glm::vec2& enemyPos);
 }
-
-DECLARE_ACTOR_EDITOR_DATA(player)

--- a/src/player_data.h
+++ b/src/player_data.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+#define GLM_FORCE_RADIANS
+#include <glm.hpp>
+
+enum PlayerType : TActorSubtype {
+	PLAYER_TYPE_SIDESCROLLER,
+	PLAYER_TYPE_OVERWORLD,
+
+	PLAYER_TYPE_COUNT
+};
+
+struct PlayerData {
+	SoundHandle jumpSound;
+	SoundHandle damageSound;
+	SoundHandle gunSound; // TEMP!
+};
+
+ACTOR_SUBTYPE_PROPERTIES(PlayerData,
+	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, jumpSound, ASSET_TYPE_SOUND, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, damageSound, ASSET_TYPE_SOUND, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(PlayerData, gunSound, ASSET_TYPE_SOUND, 1)
+);
+
+struct PlayerOverworldData {
+
+};
+
+ACTOR_SUBTYPE_PROPERTIES(PlayerOverworldData)
+
+struct PlayerFlags {
+	u8 aimMode : 2;
+	bool slowFall : 1;
+	bool doubleJumped : 1;
+	bool airDodged : 1;
+	u8 mode : 4;
+};
+
+struct PlayerState {
+	PlayerFlags flags;
+
+	u16 wingCounter;
+	u16 wingFrame;
+	u16 shootCounter;
+
+	u16 modeTransitionCounter;
+	u16 staminaRecoveryCounter;
+};
+
+struct PlayerOverworldState {
+	glm::ivec2 facingDir;
+	u16 movementCounter;
+};
+
+ACTOR_EDITOR_DATA(Player,
+	{ "sidescroller", GET_SUBTYPE_PROPERTIES(PlayerData) },
+	{ "overworld", GET_SUBTYPE_PROPERTIES(PlayerOverworldData) }
+)

--- a/src/spawner.cpp
+++ b/src/spawner.cpp
@@ -80,9 +80,3 @@ constexpr ActorDrawFn Game::spawnerDrawTable[SPAWNER_TYPE_COUNT] = {
     DrawNoOp,
     DrawNoOp,
 };
-
-DEFINE_ACTOR_EDITOR_DATA(spawner,
-    { "exp_spawner", GET_SUBTYPE_PROPERTIES(ExpSpawnerData) },
-    { "enemy_spawner", GET_SUBTYPE_PROPERTIES(EnemySpawnerData) },
-    { "loot_spawner", GET_SUBTYPE_PROPERTIES(LootSpawnerData) }
-)

--- a/src/spawner.h
+++ b/src/spawner.h
@@ -1,51 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
-#include "actor_reflection.h"
-
-enum SpawnerType : TActorSubtype {
-	SPAWNER_TYPE_EXP,
-	SPAWNER_TYPE_ENEMY,
-	SPAWNER_TYPE_LOOT,
-
-	SPAWNER_TYPE_COUNT
-};
-
-struct ExpSpawnerData {
-	ActorPrototypeHandle large;
-	ActorPrototypeHandle small;
-};
-
-ACTOR_SUBTYPE_PROPERTIES(ExpSpawnerData,
-	ACTOR_SUBTYPE_PROPERTY_ASSET(ExpSpawnerData, large, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(ExpSpawnerData, small, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
-);
-
-struct ExpSpawnerState {
-	u16 remainingValue;
-};
-
-struct EnemySpawnerData {
-};
-
-ACTOR_SUBTYPE_PROPERTIES(EnemySpawnerData);
-
-struct LootSpawnerData {
-	u8 typeCount;
-	u8 spawnRates[4];
-	ActorPrototypeHandle types[4];
-};
-
-ACTOR_SUBTYPE_PROPERTIES(LootSpawnerData,
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(LootSpawnerData, typeCount, U8, 1),
-	ACTOR_SUBTYPE_PROPERTY_SCALAR(LootSpawnerData, spawnRates, U8, 4),
-	ACTOR_SUBTYPE_PROPERTY_ASSET(LootSpawnerData, types, ASSET_TYPE_ACTOR_PROTOTYPE, 4)
-);
+#include "spawner_data.h"
 
 namespace Game {
 	extern const ActorInitFn spawnerInitTable[SPAWNER_TYPE_COUNT];
 	extern const ActorUpdateFn spawnerUpdateTable[SPAWNER_TYPE_COUNT];
 	extern const ActorDrawFn spawnerDrawTable[SPAWNER_TYPE_COUNT];
 }
-
-DECLARE_ACTOR_EDITOR_DATA(spawner)

--- a/src/spawner_data.h
+++ b/src/spawner_data.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "asset_types.h"
+#include "actor_reflection.h"
+
+enum SpawnerType : TActorSubtype {
+	SPAWNER_TYPE_EXP,
+	SPAWNER_TYPE_ENEMY,
+	SPAWNER_TYPE_LOOT,
+
+	SPAWNER_TYPE_COUNT
+};
+
+struct ExpSpawnerData {
+	ActorPrototypeHandle large;
+	ActorPrototypeHandle small;
+};
+
+ACTOR_SUBTYPE_PROPERTIES(ExpSpawnerData,
+	ACTOR_SUBTYPE_PROPERTY_ASSET(ExpSpawnerData, large, ASSET_TYPE_ACTOR_PROTOTYPE, 1),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(ExpSpawnerData, small, ASSET_TYPE_ACTOR_PROTOTYPE, 1)
+);
+
+struct ExpSpawnerState {
+	u16 remainingValue;
+};
+
+struct EnemySpawnerData {
+};
+
+ACTOR_SUBTYPE_PROPERTIES(EnemySpawnerData);
+
+struct LootSpawnerData {
+	u8 typeCount;
+	u8 spawnRates[4];
+	ActorPrototypeHandle types[4];
+};
+
+ACTOR_SUBTYPE_PROPERTIES(LootSpawnerData,
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(LootSpawnerData, typeCount, U8, 1),
+	ACTOR_SUBTYPE_PROPERTY_SCALAR(LootSpawnerData, spawnRates, U8, 4),
+	ACTOR_SUBTYPE_PROPERTY_ASSET(LootSpawnerData, types, ASSET_TYPE_ACTOR_PROTOTYPE, 4)
+);
+
+ACTOR_EDITOR_DATA(Spawner,
+	{ "exp_spawner", GET_SUBTYPE_PROPERTIES(ExpSpawnerData) },
+	{ "enemy_spawner", GET_SUBTYPE_PROPERTIES(EnemySpawnerData) },
+	{ "loot_spawner", GET_SUBTYPE_PROPERTIES(LootSpawnerData) }
+)


### PR DESCRIPTION
Separated actor data definitions from behaviour -related things. This is so I can more easily share these data definitions with tools with minimum dependencies later. I kind of hate this whole system, have to come up with something better later