### PR TITLE
Make asset loading more flexible

### DIFF
--- a/src/asset_serialization.h
+++ b/src/asset_serialization.h
@@ -29,6 +29,6 @@ namespace AssetSerialization {
 	void InitializeMetadataJson(nlohmann::json& json, u64 id);
 	SerializationResult CreateAssetMetadataFile(const std::filesystem::path& path, u64 guid, nlohmann::json& outMetadata);
 
-	SerializationResult LoadAssetFromFile(const std::filesystem::path& path, AssetType type, const nlohmann::json& metadata, size_t& size, void* pOutData);
+	SerializationResult LoadAssetFromFile(const std::filesystem::path& path, AssetType type, const nlohmann::json& metadata, std::vector<u8>& outData);
 	SerializationResult SaveAssetToFile(const std::filesystem::path& path, const char* name, AssetType type, nlohmann::json& metadata, const void* pData);
 }


### PR DESCRIPTION
No need to do two passes by first getting the size, then the data. The data is a dynamic array so the loading function can manipulate its size as it sees fit, and only then is the asset created from that data.

This paves the way for including shaders in the asset archive later. Shaders need to be compiled and we can't know the size of the compiled code before the compilation, so it makes no sense to do it in two passes