### PR TITLE
Add build option to disable asset building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
         sudo apt install -y \
           libvulkan-dev \
           libsdl2-dev \
-          glslang-tools \
           build-essential
 
     - name: Verify dependencies
@@ -28,13 +27,12 @@ jobs:
         echo "Verifying required dependencies..."
         pkg-config --exists vulkan && echo "✓ Vulkan SDK available"
         pkg-config --exists sdl2 && echo "✓ SDL2 development libraries available"
-        which glslangValidator && echo "✓ GLSL validator available"
         echo "✓ CMake version: $(cmake --version | head -1)"
         echo "✓ GCC version: $(gcc --version | head -1)"
 
     - name: Configure project
       run: |
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_EDITOR=OFF
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_ASSETS=OFF -DENABLE_EDITOR=OFF
 
     - name: Build project
       run: |
@@ -44,5 +42,5 @@ jobs:
       run: |
         cd build
         echo "Checking build outputs..."
-        ls -la pixelengine asset_packer
+        ls -la pixelengine
         echo "✓ Build completed successfully"name: Build Validation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,32 +6,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
-if(MSVC)
-set(COMPILER_FLAGS
-	"/arch:AVX2" # Enable AVX2 instructions
-	"/Zc:preprocessor" # Enable C++20 preprocessor features
-	"/permissive-" # Disable MSVC's non-standard C++ extensions
-	"/W4" # Set warning level to 4
-	"/wd4100" # Disable warning C4100: unreferenced formal parameter
-	"/wd4101" # Disable warning C4101: unreferenced local variable
-	"/wd4189" # Disable warning C4189: local variable is initialized but not referenced
-	"/wd4201" # Disable warning C4201: nonstandard extension used: nameless struct/union
-	"/wd4324" # Disable warning C4324: structure was padded due to alignment specifier
-	"/wd4505" # Disable warning C4505: unreferenced local function has been removed
-)
-else()
-set(COMPILER_FLAGS
-	"-mavx2"
-	"-Wall"
-	"-Wextra"
-	"-Wno-unused-parameter"
-	"-Wno-unused-variable"
-	"-Wno-unused-but-set-variable"
-	"-Wno-gnu-anonymous-struct"
-	"-Wno-padded"
-	"-Wno-unused-function"
-)
-endif()
+option(ENABLE_EDITOR "Enable editor functionality" ON)
+option(BUILD_ASSETS "Build asset archive" ON)
+
+set(ASSETS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/assets")
+set(ASSETS_NPAK_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/assets.npak")
 
 # For FetchContent_Declare() and FetchContent_MakeAvailable()
 include(FetchContent)
@@ -47,8 +26,10 @@ FetchContent_Declare(
 		nlohmann_json
 		GIT_REPOSITORY https://github.com/nlohmann/json.git
 		GIT_TAG v3.12.0
-	)
-FetchContent_MakeAvailable(nlohmann_json)
+)
+if(ENABLE_EDITOR OR BUILD_ASSETS)
+	FetchContent_MakeAvailable(nlohmann_json)
+endif()
 
 find_package(Vulkan REQUIRED)
 find_package(SDL2 REQUIRED)
@@ -82,28 +63,52 @@ set(SOURCES
 		src/asset_archive.cpp
 		src/asset_manager.cpp)
 
-option(ENABLE_EDITOR "Enable editor functionality" ON)
-
-set(ASSETS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/assets")
-set(ASSETS_NPAK_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/assets.npak")
-
-# Asset Packer Tool
-set (ASSET_PACKER_SOURCES 
-	src/tools/asset_packer.cpp 
-	src/asset_archive.cpp 
-	src/asset_serialization.cpp)
-
-add_executable(asset_packer ${ASSET_PACKER_SOURCES})
-target_include_directories(asset_packer PRIVATE ${glm_SOURCE_DIR})
-target_link_libraries(asset_packer PRIVATE nlohmann_json)
-target_compile_definitions(asset_packer PRIVATE EDITOR)
-target_compile_options(asset_packer PRIVATE ${COMPILER_FLAGS})
+add_executable(${PROJECT_NAME} WIN32 ${SHARED_SOURCES} ${SOURCES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${SHARED_INCLUDE_DIR} ${Vulkan_INCLUDE_DIRS} ${glm_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${Vulkan_LIBRARY} SDL2::SDL2 SDL2::SDL2main)
+target_compile_definitions(${PROJECT_NAME} PRIVATE ASSETS_NPAK_OUTPUT="${ASSETS_NPAK_OUTPUT}")
 
 if(MSVC)
-	target_compile_definitions(asset_packer PRIVATE _CRT_SECURE_NO_WARNINGS)
+	set(COMPILER_FLAGS
+		"/arch:AVX2" # Enable AVX2 instructions
+		"/Zc:preprocessor" # Enable C++20 preprocessor features
+		"/permissive-" # Disable MSVC's non-standard C++ extensions
+		"/W4" # Set warning level to 4
+		"/wd4100" # Disable warning C4100: unreferenced formal parameter
+		"/wd4101" # Disable warning C4101: unreferenced local variable
+		"/wd4189" # Disable warning C4189: local variable is initialized but not referenced
+		"/wd4201" # Disable warning C4201: nonstandard extension used: nameless struct/union
+		"/wd4324" # Disable warning C4324: structure was padded due to alignment specifier
+		"/wd4505" # Disable warning C4505: unreferenced local function has been removed
+	)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
+else()
+	set(COMPILER_FLAGS
+		"-mavx2"
+		"-Wall"
+		"-Wextra"
+		"-Wno-unused-parameter"
+		"-Wno-unused-variable"
+		"-Wno-unused-but-set-variable"
+		"-Wno-gnu-anonymous-struct"
+		"-Wno-padded"
+		"-Wno-unused-function"
+	)
 endif()
 
-IF(ENABLE_EDITOR)
+target_compile_options(${PROJECT_NAME} PRIVATE ${COMPILER_FLAGS})
+
+if(WIN32)
+	set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC PLATFORM_WINDOWS)
+endif()
+
+if(UNIX AND NOT APPLE)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC PLATFORM_LINUX)
+endif()
+
+if(ENABLE_EDITOR)
+	message(STATUS "Editor functionality enabled")
 	set(EDITOR_INCLUDE_DIRS src/ext/imgui-filebrowser)
 	set(EDITOR_SOURCES 
 		src/editor.cpp 
@@ -133,80 +138,81 @@ IF(ENABLE_EDITOR)
 		${imgui_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp)
 		
 	# Add platform-specific backends
-	IF(WIN32)
+	if(WIN32)
 		list(APPEND IMGUI_SOURCES ${imgui_SOURCE_DIR}/backends/imgui_impl_win32.cpp)
-	ENDIF()
-ENDIF()
+	endif()
 
-add_executable(${PROJECT_NAME} WIN32 ${SHARED_SOURCES} ${SOURCES})
-target_include_directories(${PROJECT_NAME} PRIVATE ${SHARED_INCLUDE_DIR} ${Vulkan_INCLUDE_DIRS} ${glm_SOURCE_DIR})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${Vulkan_LIBRARY} SDL2::SDL2 SDL2::SDL2main)
-target_compile_definitions(${PROJECT_NAME} PRIVATE ASSETS_NPAK_OUTPUT="${ASSETS_NPAK_OUTPUT}")
-target_compile_options(${PROJECT_NAME} PRIVATE ${COMPILER_FLAGS})
-
-IF(ENABLE_EDITOR)
 	target_sources(${PROJECT_NAME} PRIVATE ${IMGUI_SOURCES} ${EDITOR_SOURCES})
 	target_include_directories(${PROJECT_NAME} PRIVATE ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends ${EDITOR_INCLUDE_DIRS})
 	target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE ASSETS_SRC_DIR="${ASSETS_SRC_DIR}")
-ENDIF()
 
-if(MSVC)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
+	# Enable editor functionality
+	target_compile_definitions(${PROJECT_NAME} PUBLIC EDITOR)
+else()
+	message(STATUS "Editor functionality disabled")
 endif()
 
-# Compile shaders
-set (GLSL_SHADERS
-    src/shaders/debug_blit_chr.comp
-    src/shaders/debug_blit_pal.comp
-	src/shaders/scanline_evaluate.comp
-	src/shaders/software.comp
-	src/shaders/quad.vert
-	src/shaders/textured_crt.frag
-	src/shaders/textured_raw.frag)
+if(BUILD_ASSETS)
+	message(STATUS "Asset building enabled")
+	# Asset Packer Tool
+	set (ASSET_PACKER_SOURCES 
+		src/tools/asset_packer.cpp 
+		src/asset_archive.cpp 
+		src/asset_serialization.cpp)
 
-set(SHADER_DEST ${CMAKE_CURRENT_BINARY_DIR}/shaders)
-file(MAKE_DIRECTORY ${SHADER_DEST})
-include(${CMAKE_CURRENT_SOURCE_DIR}/glsl_shader.cmake)
-set_source_files_properties(src/shaders/debug_blit_chr.comp PROPERTIES ShaderType "comp")
-set_source_files_properties(src/shaders/debug_blit_pal.comp PROPERTIES ShaderType "comp")
-set_source_files_properties(src/shaders/scanline_evaluate.comp PROPERTIES ShaderType "comp")
-set_source_files_properties(src/shaders/software.comp PROPERTIES ShaderType "comp")
-set_source_files_properties(src/shaders/quad.vert PROPERTIES ShaderType "vert")
-set_source_files_properties(src/shaders/textured_crt.frag PROPERTIES ShaderType "frag")
-set_source_files_properties(src/shaders/textured_raw.frag PROPERTIES ShaderType "frag")
+	add_executable(asset_packer ${ASSET_PACKER_SOURCES})
+	target_include_directories(asset_packer PRIVATE ${glm_SOURCE_DIR})
+	target_link_libraries(asset_packer PRIVATE nlohmann_json)
+	target_compile_definitions(asset_packer PRIVATE EDITOR)
+	target_compile_options(asset_packer PRIVATE ${COMPILER_FLAGS})
 
-foreach(FILE ${GLSL_SHADERS})
-    get_filename_component(FILE_WE ${FILE} NAME_WE)
-    get_source_file_property(shadertype ${FILE} ShaderType)
-    glsl_spv_shader(
-            INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}"
-            OUTPUT "${SHADER_DEST}/${FILE_WE}.spv"
-            STAGE ${shadertype}
-            ENTRY_POINT main
-            TARGET_ENV vulkan1.0
-    )
-    # Make our project depend on these files
-    target_sources(${PROJECT_NAME} PRIVATE "${SHADER_DEST}/${FILE_WE}.spv")
-endforeach()
+	if(MSVC)
+		target_compile_definitions(asset_packer PRIVATE _CRT_SECURE_NO_WARNINGS)
+	endif()
 
-# Generate assets.npak from source assets
-add_custom_target(generate_assets ALL
-	COMMAND asset_packer "${ASSETS_SRC_DIR}" "${ASSETS_NPAK_OUTPUT}"
-	DEPENDS asset_packer
-	COMMENT "Generating assets.npak from source assets"
-)
-add_dependencies(${PROJECT_NAME} generate_assets)
+	# Compile shaders
+	set (GLSL_SHADERS
+		src/shaders/debug_blit_chr.comp
+		src/shaders/debug_blit_pal.comp
+		src/shaders/scanline_evaluate.comp
+		src/shaders/software.comp
+		src/shaders/quad.vert
+		src/shaders/textured_crt.frag
+		src/shaders/textured_raw.frag)
 
-IF(WIN32)
-	set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC PLATFORM_WINDOWS)
-ENDIF()
+	set(SHADER_DEST ${CMAKE_CURRENT_BINARY_DIR}/shaders)
+	file(MAKE_DIRECTORY ${SHADER_DEST})
+	include(${CMAKE_CURRENT_SOURCE_DIR}/glsl_shader.cmake)
+	set_source_files_properties(src/shaders/debug_blit_chr.comp PROPERTIES ShaderType "comp")
+	set_source_files_properties(src/shaders/debug_blit_pal.comp PROPERTIES ShaderType "comp")
+	set_source_files_properties(src/shaders/scanline_evaluate.comp PROPERTIES ShaderType "comp")
+	set_source_files_properties(src/shaders/software.comp PROPERTIES ShaderType "comp")
+	set_source_files_properties(src/shaders/quad.vert PROPERTIES ShaderType "vert")
+	set_source_files_properties(src/shaders/textured_crt.frag PROPERTIES ShaderType "frag")
+	set_source_files_properties(src/shaders/textured_raw.frag PROPERTIES ShaderType "frag")
 
-IF(UNIX AND NOT APPLE)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC PLATFORM_LINUX)
-ENDIF()
+	foreach(FILE ${GLSL_SHADERS})
+		get_filename_component(FILE_WE ${FILE} NAME_WE)
+		get_source_file_property(shadertype ${FILE} ShaderType)
+		glsl_spv_shader(
+				INPUT "${CMAKE_CURRENT_SOURCE_DIR}/${FILE}"
+				OUTPUT "${SHADER_DEST}/${FILE_WE}.spv"
+				STAGE ${shadertype}
+				ENTRY_POINT main
+				TARGET_ENV vulkan1.0
+		)
+		# Make our project depend on these files
+		target_sources(${PROJECT_NAME} PRIVATE "${SHADER_DEST}/${FILE_WE}.spv")
+	endforeach()
 
-IF(ENABLE_EDITOR)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC EDITOR)
-ENDIF()
+	# Generate assets.npak from source assets
+	add_custom_target(generate_assets ALL
+		COMMAND asset_packer "${ASSETS_SRC_DIR}" "${ASSETS_NPAK_OUTPUT}"
+		DEPENDS asset_packer
+		COMMENT "Generating assets.npak from source assets"
+	)
+	add_dependencies(${PROJECT_NAME} generate_assets)
+else()
+	message(STATUS "Asset building disabled")
+endif()


### PR DESCRIPTION
Asset building can be disabled by setting BUILD_ASSETS to OFF. Building assets is now disabled in workflows (Until I need a proper remote build system)

I also did some general cleanup of the quite messy cmakelists