### PR TITLE
Clean up asset manager interface

### DIFF
--- a/src/asset_archive.h
+++ b/src/asset_archive.h
@@ -34,7 +34,6 @@ public:
 	// Archive file operations
 	bool LoadFromFile(const std::filesystem::path& path);
 	bool SaveToFile(const std::filesystem::path& path);
-	bool CreateEmpty();
 
 	// Asset operations
 	void* AddAsset(u64 id, AssetType type, size_t size, const char* path, const char* name, const void* data = nullptr);
@@ -42,7 +41,8 @@ public:
 	bool ResizeAsset(u64 id, size_t newSize);
 	
 	// Asset retrieval
-	void* GetAssetData(u64 id, AssetType type);
+	void* GetAssetData(u64 id);
+	void* GetAssetData(const AssetEntry* pEntry);
 	AssetEntry* GetAssetEntry(u64 id);
 	AssetEntry* GetAssetEntryByPath(const std::filesystem::path& relativePath);
 	
@@ -55,17 +55,6 @@ public:
 	const AssetIndex& GetIndex() const;
 
 private:
-	// Binary search helpers for sorted asset pool
-	AssetEntry* FindAssetByIdBinary(u64 id);
-	const AssetEntry* FindAssetByIdBinary(u64 id) const;
-
-private:
-	struct ArchiveHeader {
-		char signature[4];
-		size_t assetCount;
-		size_t directoryOffset;
-	};
-
 	size_t m_capacity;
 	size_t m_size;
 	u8* m_data;
@@ -73,5 +62,7 @@ private:
 
 	bool ResizeStorage(size_t minCapacity);
 	bool ReserveMemory(size_t size);
-	static constexpr size_t GetNextPOT(size_t n);
+	// Binary search helpers for sorted asset pool
+	AssetEntry* FindAssetByIdBinary(u64 id);
+	const AssetEntry* FindAssetByIdBinary(u64 id) const;
 };

--- a/src/asset_manager.cpp
+++ b/src/asset_manager.cpp
@@ -1,140 +1,16 @@
 #include "asset_manager.h"
-#include "random.h"
-#include <cstdio>
-#include <cstring>
+#include "debug.h"
 
-#ifdef EDITOR
-#include "asset_serialization.h"
-#endif
-
-static AssetArchive g_archive;
+static AssetArchive* g_pArchive;
 
 #pragma region Public API
-bool AssetManager::LoadAssets() {
-#ifndef EDITOR
-	return LoadArchive(ASSETS_NPAK_OUTPUT);
-#else
-	return LoadAssetsFromDirectory(ASSETS_SRC_DIR);
-#endif
-}
-
-#ifdef EDITOR
-bool AssetManager::LoadAssetsFromDirectory(const std::filesystem::path& directory) {
-	if (!std::filesystem::exists(directory)) {
-		DEBUG_ERROR("Directory (%s) does not exist\n", directory.string().c_str());
-		return false;
-	}
-
-	if (!std::filesystem::is_directory(directory)) {
-		DEBUG_ERROR("Path (%s) is not a directory\n", directory.string().c_str());
-		return false;
-	}
-
-	DEBUG_LOG("Listing assets in directory: %s\n", directory.string().c_str());
-
-	std::vector<u8> data;
-	for (const auto& entry : std::filesystem::recursive_directory_iterator(directory)) {
-		AssetType assetType;
-		if (entry.is_regular_file() && AssetSerialization::TryGetAssetTypeFromPath(entry.path(), assetType) == SERIALIZATION_SUCCESS) {
-			const std::string pathStr = entry.path().string();
-			const char* pathCStr = pathStr.c_str();
-			DEBUG_LOG("Found %s: %s\n", ASSET_TYPE_NAMES[assetType], pathCStr);
-
-			nlohmann::json metadata;
-			if (!AssetSerialization::HasMetadata(entry.path())) {
-				DEBUG_LOG("No metadata found for asset %s, creating new metadata file\n", pathCStr);
-				u64 guid = Random::GenerateUUID();
-				if (AssetSerialization::CreateAssetMetadataFile(entry.path(), guid, metadata) != SERIALIZATION_SUCCESS) {
-					DEBUG_ERROR("Failed to create metadata for asset %s\n", pathCStr);
-					continue;
-				}
-			}
-
-			if (AssetSerialization::LoadAssetMetadataFromFile(entry.path(), metadata) != SERIALIZATION_SUCCESS) {
-				DEBUG_ERROR("Failed to load metadata for asset %s\n", pathCStr);
-				continue;
-			}
-
-			const u64 guid = metadata["guid"];
-
-			data.clear();
-			if (AssetSerialization::LoadAssetFromFile(entry.path(), assetType, metadata, data) != SERIALIZATION_SUCCESS) {
-				DEBUG_ERROR("Failed to load asset %s\n", pathCStr);
-				continue;
-			}
-			const std::string filenameWithoutExt = entry.path().filename().replace_extension("").string();
-			std::string name = filenameWithoutExt;
-			if (metadata.contains("name") && !metadata["name"].is_null())
-			{
-				name = metadata["name"].get<std::string>();
-			}
-
-			const std::filesystem::path relativePath = std::filesystem::relative(entry.path(), ASSETS_SRC_DIR);
-			if (!AddAsset(guid, assetType, data.size(), relativePath.string().c_str(), name.c_str(), data.data())) {
-				DEBUG_ERROR("Failed to add asset %s to manager\n", pathCStr);
-				continue;
-			}
-			DEBUG_LOG("Asset %s loaded successfully with GUID: %llu\n", pathCStr, guid);
-		}
-	}
-
-	return true;
-}
-#endif
-
-bool AssetManager::LoadArchive(const std::filesystem::path& path) {
-	return g_archive.LoadFromFile(path);
-}
-
-bool AssetManager::SaveArchive(const std::filesystem::path& path) {
-	return g_archive.SaveToFile(path);
-}
-
-bool AssetManager::RepackArchive() {
-	g_archive.Repack();
-	return true;
-}
-
-u64 AssetManager::CreateAsset(AssetType type, size_t size, const char* path, const char* name) {
-	DEBUG_LOG("Creating new asset of size %d with name %s\n", size, name);
-
-	const u64 id = Random::GenerateUUID();
-	void* data = g_archive.AddAsset(id, type, size, path, name, nullptr);
-	if (!data) {
-		return UUID_NULL;
-	}
-
-	return id;
-}
-
-void* AssetManager::AddAsset(u64 id, AssetType type, size_t size, const char* path, const char* name, void* data) {
-	return g_archive.AddAsset(id, type, size, path, name, data);
-}
-
-bool AssetManager::RemoveAsset(u64 id) {
-	if (!g_archive.RemoveAsset(id)) {
-		DEBUG_ERROR("Asset with ID %llu does not exist\n", id);
-		return false;
-	}
-
-	DEBUG_LOG("Removing asset %llu\n", id);
-	return true;
-}
-
-bool AssetManager::ResizeAsset(u64 id, size_t newSize) {
-	AssetEntry* asset = g_archive.GetAssetEntry(id);
-	if (!asset) {
-		return false;
-	}
-	
-	const size_t oldSize = asset->size;
-	DEBUG_LOG("Resizing asset %lld (%d -> %d)\n", id, oldSize, newSize);
-
-	return g_archive.ResizeAsset(id, newSize);
+bool AssetManager::Init(AssetArchive* pArchive) {
+	g_pArchive = pArchive;
+	return g_pArchive != nullptr;
 }
 
 u64 AssetManager::GetAssetId(const std::filesystem::path& relativePath, AssetType type) {
-	AssetEntry* pAssetInfo = g_archive.GetAssetEntryByPath(relativePath);
+	const AssetEntry* pAssetInfo = g_pArchive->GetAssetEntryByPath(relativePath);
 	if (!pAssetInfo) {
 		DEBUG_ERROR("Asset with path '%s' not found\n", relativePath.string().c_str());
 		return UUID_NULL;
@@ -146,27 +22,16 @@ u64 AssetManager::GetAssetId(const std::filesystem::path& relativePath, AssetTyp
 	return pAssetInfo->id;
 }
 
-void* AssetManager::GetAsset(u64 id, AssetType type) {
-	return g_archive.GetAssetData(id, type);
-}
-
-AssetEntry* AssetManager::GetAssetInfo(u64 id) {
-	return g_archive.GetAssetEntry(id);
-}
-
-const char* AssetManager::GetAssetName(u64 id) {
-	const AssetEntry* pAssetInfo = GetAssetInfo(id);
+const void* AssetManager::GetAsset(u64 id, AssetType type) {
+	const AssetEntry* pAssetInfo = g_pArchive->GetAssetEntry(id);
 	if (!pAssetInfo) {
+		DEBUG_ERROR("Asset %llu not found\n", id);
 		return nullptr;
 	}
-	return pAssetInfo->name;
-}
-
-size_t AssetManager::GetAssetCount() {
-	return g_archive.GetAssetCount();
-}
-
-const AssetIndex& AssetManager::GetIndex() {
-	return g_archive.GetIndex();
+	if (pAssetInfo->flags.type != type) {
+		DEBUG_ERROR("Asset %llu is not of type %d\n", id, type);
+		return nullptr;
+	}
+	return g_pArchive->GetAssetData(pAssetInfo);
 }
 #pragma endregion

--- a/src/asset_manager.h
+++ b/src/asset_manager.h
@@ -1,32 +1,8 @@
 #pragma once
-#include "typedef.h"
-#include "asset_types.h"
 #include "asset_archive.h"
-#include "debug.h"
-#include <filesystem>
 
 namespace AssetManager {
-	bool LoadAssets();
-#ifdef EDITOR
-	bool LoadAssetsFromDirectory(const std::filesystem::path& directory);
-#endif
-
-	bool LoadArchive(const std::filesystem::path& path);
-	bool SaveArchive(const std::filesystem::path& path);
-	bool RepackArchive();
-
-	u64 CreateAsset(AssetType type, size_t size, const char* path, const char* name);
-	template <IsAssetHandle HandleType>
-	HandleType CreateAsset(u32 size, const char* path, const char* name) {
-		constexpr AssetType assetType = AssetHandleTraits<HandleType>::asset_type::value;
-		const u64 id = CreateAsset(assetType, size, path, name);
-		return HandleType{ id };
-	}
-
-	void* AddAsset(u64 id, AssetType type, size_t size, const char* path, const char* name, void* data = nullptr);
-	bool RemoveAsset(u64 id);
-
-	bool ResizeAsset(u64 id, size_t newSize);
+	bool Init(AssetArchive* pArchive);
 
 	u64 GetAssetId(const std::filesystem::path& relativePath, AssetType type);
 	template <IsAssetHandle HandleType>
@@ -35,17 +11,11 @@ namespace AssetManager {
 		u64 id = GetAssetId(relativePath, assetType);
 		return HandleType{ id };
 	}
-	void* GetAsset(u64 id, AssetType type);
+	const void* GetAsset(u64 id, AssetType type);
 	template <IsAssetHandle HandleType>
-	typename AssetHandleTraits<HandleType>::data_type* GetAsset(const HandleType& handle) {
+	const typename AssetHandleTraits<HandleType>::data_type* GetAsset(const HandleType& handle) {
 		constexpr AssetType assetType = AssetHandleTraits<HandleType>::asset_type::value;
 		using T = typename AssetHandleTraits<HandleType>::data_type;
 		return (T*)GetAsset(handle.id, assetType);
 	}
-
-	AssetEntry* GetAssetInfo(u64 id);
-	const char* GetAssetName(u64 id);
-
-	size_t GetAssetCount();
-	const AssetIndex& GetIndex();
 }

--- a/src/editor.h
+++ b/src/editor.h
@@ -1,12 +1,13 @@
 #pragma once
-#include "typedef.h"
+#include "asset_archive.h"
 #include <cstdarg>
+#include <filesystem>
 
 struct SDL_Window;
 union SDL_Event;
 
 namespace Editor {
-	void CreateContext();
+	void CreateContext(AssetArchive *pAssetArchive);
 	void Init(SDL_Window* pWindow);
 	void Free();
 	void DestroyContext();
@@ -18,4 +19,10 @@ namespace Editor {
 	void Update(r64 dt);
 	void SetupFrame();
 	void Render();
+
+	namespace Assets {
+		bool LoadSourceAssetsFromDirectory(const std::filesystem::path& directory, AssetArchive* pArchive);
+		void InitializeAsset(AssetType type, void* pData);
+		u32 GetAssetSize(AssetType type, const void* pData);
+	}
 }

--- a/src/editor_assets.cpp
+++ b/src/editor_assets.cpp
@@ -1,6 +1,8 @@
-#include "editor_assets.h"
+#include "editor.h"
 #include "debug.h"
+#include "random.h"
 #include "actor_data.h"
+#include "asset_serialization.h"
 
 #pragma region Size calculation
 static u32 GetRoomTemplateSize(const RoomTemplate* pHeader) {
@@ -161,6 +163,69 @@ static void InitOverworld(void* data) {
 	}
 }
 #pragma endregion
+
+// TODO: Set up a file watcher for the assets directory
+bool Editor::Assets::LoadSourceAssetsFromDirectory(const std::filesystem::path& directory, AssetArchive* pArchive) {
+	if (!std::filesystem::exists(directory)) {
+		DEBUG_ERROR("Directory (%s) does not exist\n", directory.string().c_str());
+		return false;
+	}
+
+	if (!std::filesystem::is_directory(directory)) {
+		DEBUG_ERROR("Path (%s) is not a directory\n", directory.string().c_str());
+		return false;
+	}
+
+	DEBUG_LOG("Listing assets in directory: %s\n", directory.string().c_str());
+
+	std::vector<u8> data;
+	for (const auto& entry : std::filesystem::recursive_directory_iterator(directory)) {
+		AssetType assetType;
+		if (entry.is_regular_file() && AssetSerialization::TryGetAssetTypeFromPath(entry.path(), assetType) == SERIALIZATION_SUCCESS) {
+			const std::string pathStr = entry.path().string();
+			const char* pathCStr = pathStr.c_str();
+			DEBUG_LOG("Found %s: %s\n", ASSET_TYPE_NAMES[assetType], pathCStr);
+
+			nlohmann::json metadata;
+			if (!AssetSerialization::HasMetadata(entry.path())) {
+				DEBUG_LOG("No metadata found for asset %s, creating new metadata file\n", pathCStr);
+				u64 guid = Random::GenerateUUID();
+				if (AssetSerialization::CreateAssetMetadataFile(entry.path(), guid, metadata) != SERIALIZATION_SUCCESS) {
+					DEBUG_ERROR("Failed to create metadata for asset %s\n", pathCStr);
+					continue;
+				}
+			}
+
+			if (AssetSerialization::LoadAssetMetadataFromFile(entry.path(), metadata) != SERIALIZATION_SUCCESS) {
+				DEBUG_ERROR("Failed to load metadata for asset %s\n", pathCStr);
+				continue;
+			}
+
+			const u64 guid = metadata["guid"];
+
+			data.clear();
+			if (AssetSerialization::LoadAssetFromFile(entry.path(), assetType, metadata, data) != SERIALIZATION_SUCCESS) {
+				DEBUG_ERROR("Failed to load asset %s\n", pathCStr);
+				continue;
+			}
+			const std::string filenameWithoutExt = entry.path().filename().replace_extension("").string();
+			std::string name = filenameWithoutExt;
+			if (metadata.contains("name") && !metadata["name"].is_null())
+			{
+				name = metadata["name"].get<std::string>();
+			}
+
+			const std::filesystem::path relativePath = std::filesystem::relative(entry.path(), ASSETS_SRC_DIR);
+			if (!pArchive->AddAsset(guid, assetType, data.size(), relativePath.string().c_str(), name.c_str(), data.data())) {
+				DEBUG_ERROR("Failed to add asset %s to manager\n", pathCStr);
+				continue;
+			}
+			DEBUG_LOG("Asset %s loaded successfully with GUID: %llu\n", pathCStr, guid);
+		}
+	}
+
+	return true;
+}
 
 void Editor::Assets::InitializeAsset(AssetType type, void* pData) {
 	switch (type) {

--- a/src/editor_assets.h
+++ b/src/editor_assets.h
@@ -1,9 +1,0 @@
-#pragma once
-#include "asset_types.h"
-#include <filesystem>
-#include <map>
-
-namespace Editor::Assets {
-	void InitializeAsset(AssetType type, void* pData);
-	u32 GetAssetSize(AssetType type, const void* pData);
-}

--- a/src/game_rendering.cpp
+++ b/src/game_rendering.cpp
@@ -5,6 +5,7 @@
 #include "rendering_util.h"
 #include "game.h"
 #include "asset_manager.h"
+#include "debug.h"
 
 static constexpr s32 BUFFER_DIM_METATILES = 2;
 static constexpr u32 LAYER_SPRITE_COUNT = MAX_SPRITE_COUNT / SPRITE_LAYER_COUNT;
@@ -325,7 +326,7 @@ bool Game::Rendering::DrawMetasprite(u8 layerIndex, MetaspriteHandle metaspriteH
 }
 
 void Game::Rendering::CopyBankTiles(ChrBankHandle bankHandle, u32 bankOffset, u32 sheetIndex, u32 sheetOffset, u32 count) {
-	ChrSheet* pBank = AssetManager::GetAsset(bankHandle);
+	const ChrSheet* pBank = AssetManager::GetAsset(bankHandle);
 	if (!pBank) {
 		DEBUG_ERROR("Failed to load bank %llu\n", bankHandle);
 		return;
@@ -338,7 +339,7 @@ void Game::Rendering::CopyBankTiles(ChrBankHandle bankHandle, u32 bankOffset, u3
 }
 
 bool Game::Rendering::GetPalettePresetColors(PaletteHandle paletteHandle, u8* pOutColors) {
-    Palette* pPalette = AssetManager::GetAsset(paletteHandle);
+    const Palette* pPalette = AssetManager::GetAsset(paletteHandle);
     if (!pPalette) {
         DEBUG_ERROR("Failed to load palette %llu\n", paletteHandle);
         return false;
@@ -353,7 +354,7 @@ void Game::Rendering::WritePaletteColors(u8 paletteIndex, u8* pColors) {
 }
 
 void Game::Rendering::CopyPaletteColors(PaletteHandle paletteHandle, u8 paletteIndex) {
-	Palette* pPalette = AssetManager::GetAsset(paletteHandle);
+	const Palette* pPalette = AssetManager::GetAsset(paletteHandle);
 	if (!pPalette) {
 		DEBUG_ERROR("Failed to load palette %llu\n", paletteHandle);
 		return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,13 @@ static void UpdateWindowTitle(SDL_Window* pWindow, r64 averageFramerate, r64 dt)
 }
 
 int main(int argc, char** argv) {
-    AssetManager::LoadAssets();
+    AssetArchive assetArchive;
+#ifdef EDITOR
+	Editor::Assets::LoadSourceAssetsFromDirectory(ASSETS_SRC_DIR, &assetArchive);
+#else
+    assetArchive.LoadFromFile(ASSETS_NPAK_OUTPUT);
+#endif
+    AssetManager::Init(&assetArchive);
 
     SDL_Init(SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS | SDL_INIT_HAPTIC);
     SDL_Window* pWindow = SDL_CreateWindow(WINDOW_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1536, 864, SDL_WINDOW_VULKAN | SDL_WINDOW_SHOWN);
@@ -73,7 +79,7 @@ int main(int argc, char** argv) {
     Audio::Init();
 
 #ifdef EDITOR
-    Editor::CreateContext();
+    Editor::CreateContext(&assetArchive);
     Editor::Init(pWindow);
 #endif
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -778,7 +778,7 @@ bool Game::PlayerInvulnerable(Actor* pPlayer) {
 void Game::PlayerTakeDamage(Actor* pPlayer, const Damage& damage, const glm::vec2& enemyPos) {
     u16 health = GetPlayerHealth();
 
-    ActorPrototype* pPrototype = AssetManager::GetAsset(pPlayer->prototypeHandle);
+    const ActorPrototype* pPrototype = AssetManager::GetAsset(pPlayer->prototypeHandle);
     if (pPrototype && pPrototype->data.playerData.damageSound != SoundHandle::Null()) {
         Audio::PlaySFX(pPrototype->data.playerData.damageSound);
     }

--- a/src/random.h
+++ b/src/random.h
@@ -3,8 +3,6 @@
 #define GLM_FORCE_RADIANS
 #include <glm.hpp>
 
-constexpr u64 UUID_NULL = 0;
-
 namespace Random {
 	u64 GenerateUUID();
 	u32 GenerateUUID32();

--- a/src/rendering_vulkan.cpp
+++ b/src/rendering_vulkan.cpp
@@ -477,7 +477,7 @@ static VkShaderModule CreateShaderModule(VkDevice device, u8* code, const u32 si
 }
 
 static VkShaderModule CreateShaderModule(ShaderHandle handle) {
-	Shader* pShader = AssetManager::GetAsset(handle);
+	const Shader* pShader = AssetManager::GetAsset(handle);
 	if (!pShader) {
 		return VK_NULL_HANDLE;
 	}

--- a/src/typedef.h
+++ b/src/typedef.h
@@ -38,3 +38,5 @@ typedef uint64 u64;
 
 typedef real32 r32;
 typedef real64 r64;
+
+constexpr u64 UUID_NULL = 0;


### PR DESCRIPTION
Asset manager is used by the game to fetch assets, and should be used for nothing else, especially not ifdeffed editor-only functionality. I removed all of that. The asset archive itself is now injected from initialization, and if in editor mode, the editor can do its own things to it (load from sources, manipulate assets etc.)

Not perfect, but probably better.