### PR TITLE
Fix crash caused by AssetArchive destructor

### DIFF
--- a/src/asset_archive.cpp
+++ b/src/asset_archive.cpp
@@ -15,10 +15,6 @@ AssetArchive::AssetArchive()
 	: m_capacity(0), m_size(0), m_data(nullptr) {
 }
 
-AssetArchive::~AssetArchive() {
-	Clear();
-}
-
 constexpr size_t AssetArchive::GetNextPOT(size_t n) {
 	if (n == 0) {
 		return 1;

--- a/src/asset_archive.h
+++ b/src/asset_archive.h
@@ -29,7 +29,6 @@ typedef Pool<AssetEntry, MAX_ASSETS> AssetIndex;
 class AssetArchive {
 public:
 	AssetArchive();
-	~AssetArchive();
 
 	// Archive file operations
 	bool LoadFromFile(const std::filesystem::path& path);

--- a/src/asset_manager.cpp
+++ b/src/asset_manager.cpp
@@ -18,6 +18,10 @@ bool AssetManager::LoadAssets() {
 #endif
 }
 
+void AssetManager::Free() {
+	g_archive.Clear();
+}
+
 #ifdef EDITOR
 bool AssetManager::LoadAssetsFromDirectory(const std::filesystem::path& directory) {
 	if (!std::filesystem::exists(directory)) {

--- a/src/asset_manager.h
+++ b/src/asset_manager.h
@@ -7,6 +7,7 @@
 
 namespace AssetManager {
 	bool LoadAssets();
+	void Free();
 #ifdef EDITOR
 	bool LoadAssetsFromDirectory(const std::filesystem::path& directory);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,9 +138,10 @@ int main(int argc, char** argv) {
     Editor::Free();
     Editor::DestroyContext();
 #endif
-    Rendering::Free();
 
+    Rendering::Free();
     Audio::Free();
+    AssetManager::Free();
 
     SDL_DestroyWindow(pWindow);
     SDL_Quit();

--- a/src/tools/asset_packer.cpp
+++ b/src/tools/asset_packer.cpp
@@ -85,5 +85,8 @@ int main(int argc, char* argv[]) {
 
 	std::cout << "Assets successfully packed into " << outputFile << std::endl;
 
+	// This isn't necessary, but I suppose it doesn't hurt to explicity free the memory
+	archive.Clear();
+
 	return 0;
 }


### PR DESCRIPTION
Program crashed after main, when AssetArchive tried to pop from an arena that no longer existed in its destructor. Non-trivial destructors are an antipattern in my code, too object oriented to my liking. Memory should be managed by systems instead of individual objects